### PR TITLE
Update deprecated script used to inject the AAF icons for sign-ups

### DIFF
--- a/about.json
+++ b/about.json
@@ -38,7 +38,7 @@
     "https://github.com/discourse/discourse-welcome-link-banner",
     "https://github.com/discourse/discourse-search-banner.git",
     "https://github.com/moin-Jana/prefilled-composer-generator",
-    "https://github.com/discourse/discourse-color-scheme-toggle"
+    "https://github.com/discourse/discourse-color-scheme-toggle",
     "https://github.com/discourse/discourse-hide-auth-method"
   ],
   "modifiers": {},

--- a/common/header.html
+++ b/common/header.html
@@ -1,3 +1,3 @@
-<script type="text/discourse-plugin" version="0.8">
-    api.replaceIcon('right-to-bracket', 'access-nri-aaf-icon-32x32')
-</script>
+<!--<script type="text/discourse-plugin" version="0.8">-->
+    <!--api.replaceIcon('right-to-bracket', 'access-nri-aaf-icon-32x32')-->
+<!--</script>-->

--- a/common/header.html
+++ b/common/header.html
@@ -1,3 +1,0 @@
-<!--<script type="text/discourse-plugin" version="0.8">-->
-    <!--api.replaceIcon('right-to-bracket', 'access-nri-aaf-icon-32x32')-->
-<!--</script>-->

--- a/javascripts/discourse/api-initializers/init-theme.js
+++ b/javascripts/discourse/api-initializers/init-theme.js
@@ -1,0 +1,5 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer((api)) => {
+    api.replaceIcon('right-to-bracket', 'access-nri-aaf-icon-32x32')
+});


### PR DESCRIPTION
The ```<script type='text/discourse-plugin>``` bit we used to replace the right-to-bracket icon with the AAF icon is being deprecated. Followed the method described [here](https://meta.discourse.org/t/modernizing-inline-script-tags-for-templates-js-api/366482) to replace the script. Checked the ```dev``` theme in preview mode and the AAF icon still seems to be there.

Was also a small error in ```about.json``` that I had just quickly fixed on the ```main```, which hadn't propagated back here.